### PR TITLE
FIX double.fs -- missed immediacy

### DIFF
--- a/double.fs
+++ b/double.fs
@@ -11,10 +11,10 @@ primitive 2@
 : 2CONSTANT ( x1 x2 -- )  CREATE , , DOES> 2@ ;
 
 primitive POSTPONE
-: 2>R ( x1 x2 -- ) ( R: -- x2 x1 ) POSTPONE >R  POSTPONE >R ;
-: 2R> ( R: x1 x2 -- ) ( -- x2 x1 )  POSTPONE R>  POSTPONE R> ;
-: 2R@ ( R: x1 x2 -- x1 x2 ) ( -- x2 x1 )   POSTPONE 2R>  POSTPONE 2DUP  POSTPONE 2>R ;
+: 2>R ( x1 x2 -- ) ( R: -- x2 x1 ) POSTPONE >R  POSTPONE >R ; IMMEDIATE
+: 2R> ( R: x1 x2 -- ) ( -- x2 x1 )  POSTPONE R>  POSTPONE R> ; IMMEDIATE
+: 2R@ ( R: x1 x2 -- x1 x2 ) ( -- x2 x1 )   POSTPONE 2R>  POSTPONE 2DUP  POSTPONE 2>R ; IMMEDIATE
 : 2ROT ( d1 d2 d3 -- d2 d3 d1 )  2>R 2SWAP 2R> 2SWAP ;
 
 primitive LITERAL
-: 2LITERAL ( x1 x2 -- )  SWAP POSTPONE LITERAL  POSTPONE LITERAL ;
+: 2LITERAL ( x1 x2 -- )  SWAP POSTPONE LITERAL  POSTPONE LITERAL ; IMMEDIATE


### PR DESCRIPTION
`IMMEDIATE` is missed for `2LITERAL` and R-words.